### PR TITLE
fix: resolve session loss on refresh, stats 422 error, profile save a…

### DIFF
--- a/frontend/js/core/router.js
+++ b/frontend/js/core/router.js
@@ -20,7 +20,8 @@ class Router {
 
     init() {
         window.addEventListener('hashchange', () => this.handleRoute());
-        this.handleRoute();
+        // Routes are registered in app.js after this module loads.
+        // app.js calls router.handleRoute() explicitly once all routes are set up.
     }
 
     handleRoute() {

--- a/frontend/js/pages/profile.js
+++ b/frontend/js/pages/profile.js
@@ -74,15 +74,34 @@ window.handleProfileSave = async function(event) {
     event.preventDefault();
     const form    = event.target;
     const saveBtn = document.getElementById('profileSaveBtn');
-    const newPw   = form.new_password.value;
-    const confPw  = form.confirm_password.value;
+    const currentPw = form.current_password.value;
+    const newPw     = form.new_password.value;
+    const confPw    = form.confirm_password.value;
+
     if (newPw && newPw !== confPw) { Toast.error('Passwords do not match'); return; }
+    if (newPw && !currentPw) { Toast.error('Enter your current password to set a new one'); return; }
+
     saveBtn.disabled = true;
     saveBtn.textContent = 'Saving...';
     try {
+        // Save profile info to localStorage
         const currentUser = authService.getUser() || {};
-        const updated = { ...currentUser, full_name: form.full_name.value.trim(), email: form.email.value.trim() };
+        const updated = {
+            ...currentUser,
+            full_name: form.full_name.value.trim(),
+            email:     form.email.value.trim(),
+            birthdate: form.birthdate.value,
+        };
         localStorage.setItem('user', JSON.stringify(updated));
+
+        // Change password if fields are filled
+        if (newPw && currentPw) {
+            await authService.changePassword(currentPw, newPw);
+            form.current_password.value = '';
+            form.new_password.value     = '';
+            form.confirm_password.value = '';
+        }
+
         Toast.success('Profile saved!');
     } catch (err) {
         Toast.error(err.message || 'Failed to save profile');

--- a/frontend/js/pages/statistics.js
+++ b/frontend/js/pages/statistics.js
@@ -12,7 +12,10 @@ const statsService = {
         return await api.get('/stats/overall');
     },
     async fetchBreakdown(type) {
-        return await api.get(`/stats/overall-by-type?type=${type}`);
+        if (!type || type === 'all') {
+            return await api.get('/stats/overall');
+        }
+        return await api.get(`/stats/overall-by-type?type=${encodeURIComponent(type)}`);
     }
 };
 
@@ -208,9 +211,9 @@ function createStatisticsContentHTML(insightsData, breakdownData) {
             <div class="stat-card-large">
                 <h3>Breakdown</h3>
                 <div class="insights-tabs">
-                    <button class="tab-btn active" onclick="changeBreakdownPeriod('day')">Day</button>
-                    <button class="tab-btn" onclick="changeBreakdownPeriod('week')">Week</button>
-                    <button class="tab-btn" onclick="changeBreakdownPeriod('month')">Month</button>
+                    <button class="tab-btn active" onclick="changeBreakdownPeriod('all')">All</button>
+                    <button class="tab-btn" onclick="changeBreakdownPeriod('One Time')">One Time</button>
+                    <button class="tab-btn" onclick="changeBreakdownPeriod('Repeating')">Repeating</button>
                 </div>
                 <p class="stat-date" id="breakdownDate">${breakdownData.date || ''}</p>
                 <div class="circular-chart">
@@ -276,7 +279,7 @@ function _transformOverallOut(apiResponse, colorMap) {
 // ============================================
 
 let _currentInsightsPeriod  = 'week';
-let _currentBreakdownPeriod = 'day';
+let _currentBreakdownPeriod = 'all';
 
 async function loadStatisticsPage() {
     const container = document.getElementById('statisticsContainer');
@@ -346,7 +349,7 @@ window.changeInsightsPeriod = async function(period) {
 window.changeBreakdownPeriod = async function(period) {
     _currentBreakdownPeriod = period;
     document.querySelectorAll('.stat-card-large:last-child .tab-btn').forEach(btn => {
-        btn.classList.toggle('active', btn.textContent.toLowerCase() === period);
+        btn.classList.toggle('active', btn.textContent === period || (period === 'all' && btn.textContent === 'All'));
     });
     await loadStatisticsPage();
 };

--- a/frontend/js/services/auth.service.js
+++ b/frontend/js/services/auth.service.js
@@ -83,9 +83,11 @@ const authService = {
     },
 
     // Change password (authenticated)
-    async changePassword(email) {
-        const response = await api.post('/auth/forgot-password', { email });
-        return response;
+    async changePassword(currentPassword, newPassword) {
+        return await api.post('/auth/change-password', {
+            current_password: currentPassword,
+            new_password: newPassword
+        });
     }
 };
 


### PR DESCRIPTION
Session lost on page refresh
  The router was calling handleRoute() inside its constructor, before any routes were registered. This caused every page
   load to find zero matching routes and redirect to /login, overwriting the current URL. Removed the premature call —
  the router now waits for app.js to finish registering all routes before handling the initial route.

  Statistics page 422 error
  The breakdown section was passing time-period values (day, week, month) as the type query parameter to
  /stats/overall-by-type, which only accepts One Time or Repeating. Changed the breakdown tabs to All / One Time /
  Repeating to match the actual API contract. The "All" tab now calls /stats/overall (no filter).

  Birthdate not saving
  handleProfileSave was building the updated user object with only full_name and email — birthdate was read from the
  form but never included. Added it to the saved object.

  Password change not working
  authService.changePassword was calling /auth/forgot-password (sends a reset email) instead of /auth/change-password.
  Fixed the method signature and endpoint. Also wired up the password fields in handleProfileSave so they actually
  trigger the API call when filled in.

  Files changed

  - frontend/js/core/router.js
  - frontend/js/pages/statistics.js
  - frontend/js/pages/profile.js
  - frontend/js/services/auth.service.js