### PR TITLE
fix: load progress bars immediately without flash of 0%, remove sidebar item bg on hover

### DIFF
--- a/frontend/css/layout-styles.css
+++ b/frontend/css/layout-styles.css
@@ -213,7 +213,7 @@
 }
 
 .project-item:hover {
-    background: #FAFAFA;
+    transform: translateY(-1px);
 }
 
 .sidebar-project-button-container {

--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -393,11 +393,10 @@ body.dark-mode .projects-dropdown {
   background: #1a1a2e;
 }
 body.dark-mode .project-item {
-  background: #1a1a2e;
   border-bottom-color: #2a2a3e;
 }
 body.dark-mode .project-item:hover {
-  background: #242438;
+  transform: translateY(-1px);
 }
 body.dark-mode .project-name {
   color: #e0e0e0;

--- a/frontend/js/components/layout.js
+++ b/frontend/js/components/layout.js
@@ -108,13 +108,26 @@ window.loadSidebarProjects = async function () {
       listEl.innerHTML = `<div class="sidebar-projects-state">No projects yet</div>`;
       return;
     }
+
+    // Fetch all stats in parallel before rendering so bars show correct values immediately
+    const statsMap = {};
+    await Promise.all(active.map(async (g) => {
+      const progress = await statsManager.getTodayProgress(g.id, g.duration_min || 0, false);
+      statsMap[g.id] = progress;
+    }));
+
     listEl.innerHTML = active
       .map((g) => {
         const color = colorManager.getColor(g.id, g.title);
         const durationMin = g.duration_min || 0;
-        const h = Math.floor(durationMin / 60);
-        const m = durationMin % 60;
-        const timeStr = `0h 00m / ${h}h ${String(m).padStart(2, "0")}m`;
+        const stats = statsMap[g.id] || {};
+        const totalMinutes = stats.totalMinutes || 0;
+        const progressPercent = stats.percentage || 0;
+        const h = Math.floor(totalMinutes / 60);
+        const m = totalMinutes % 60;
+        const timeStr = durationMin > 0
+          ? `${h}h ${String(m).padStart(2, "0")}m / ${Math.floor(durationMin/60)}h ${String(durationMin%60).padStart(2, "0")}m`
+          : `${h}h ${String(m).padStart(2, "0")}m`;
         return `
                 <div class="project-item" data-goal-id="${g.id}" onclick="router.navigate('/goal/${g.id}')">
                     <div class="sidebar-project-button-container">
@@ -126,20 +139,15 @@ window.loadSidebarProjects = async function () {
                         <span class="project-name">${g.title || "Untitled"}</span>
                         <span class="project-progress-text">${timeStr}</span>
                         <div class="project-progress-bar">
-                            <div class="project-progress-fill" style="width:0; background:${color};"></div>
+                            <div class="project-progress-fill" style="width:${progressPercent}%; background:${color};"></div>
                         </div>
                     </div>
                 </div>
             `;
       })
       .join("");
-    
-    // Fetch and update progress for each sidebar project (initial load)
-    active.forEach(g => {
-      _fetchAndUpdateSidebarProgress(g.id, g.duration_min);
-    });
 
-    // Start polling for updates
+    // Start polling for live updates
     statsManager.startPolling(active.map(g => g.id));
   } catch (err) {
     if (listEl)

--- a/frontend/js/pages/goals.js
+++ b/frontend/js/pages/goals.js
@@ -93,12 +93,12 @@ function _createErrorState(message) {
 // GOAL CARD (active goal)
 // ============================================
 
-function createGoalCard(goal) {
+function createGoalCard(goal, stats = null) {
     const color       = _getGoalColor(goal);
-    const progress    = goal.is_complete ? 100 : 0;  // Will be updated by renderGoalsPage after fetching stats
     const durationMin = goal.duration_min || 0;
-    const todayMinutes = 0;  // Will be updated
-    const timeDisplay = durationMin > 0 ? `${Math.floor(todayMinutes/60)}h ${todayMinutes%60}m / ${_fmtMin(durationMin)}` : '0h 00m';
+    const totalMinutes = stats?.totalMinutes || 0;
+    const progress    = goal.is_complete ? 100 : (stats?.percentage || 0);
+    const timeDisplay = durationMin > 0 ? `${Math.floor(totalMinutes/60)}h ${String(totalMinutes%60).padStart(2,'0')}m / ${_fmtMin(durationMin)}` : (totalMinutes > 0 ? `${Math.floor(totalMinutes/60)}h ${String(totalMinutes%60).padStart(2,'0')}m` : '0h 00m');
     const progressFill = Math.max(0, Math.min(100, progress));
 
     return `
@@ -124,7 +124,7 @@ function createGoalCard(goal) {
     `;
 }
 
-function createGoalsList(goals) {
+function createGoalsList(goals, statsMap = {}) {
     if (!goals || goals.length === 0) {
         return `
             <div class="empty-state">
@@ -137,34 +137,36 @@ function createGoalsList(goals) {
     }
     return `
         <div class="project-cards-container">
-            ${goals.map(g => createGoalCard(g)).join('')}
+            ${goals.map(g => createGoalCard(g, statsMap[g.id] || null)).join('')}
         </div>
     `;
 }
 
-// Update progress bars after rendering (fetches today's stats)
-async function _updateGoalsProgress(goals) {
-    // Register callback for live updates
+// Fetch stats for all goals in parallel, returns a statsMap { goalId: { percentage, totalMinutes, ... } }
+async function _fetchAllGoalStats(goals) {
+    const statsMap = {};
+    await Promise.all(goals.map(async (goal) => {
+        const durationMin = goal.duration_min || 0;
+        const progress = await statsManager.getTodayProgress(goal.id, durationMin, false);
+        statsMap[goal.id] = progress;
+    }));
+    return statsMap;
+}
+
+// Register live-update callback for progress bars (after initial render)
+function _updateGoalsProgress(goals) {
     statsManager.subscribe((goalId, todayMinutes, totalMinutes, percentage) => {
         const goal = goals.find(g => g.id === goalId);
         if (!goal) return;
-        
-        const color = _getGoalColor(goal);
-        
-        // Update card element
+
         const cardEl = document.querySelector(`[data-goal-id="${goalId}"]`);
         if (cardEl) {
-            // Update progress bar
             const fill = cardEl.querySelector('.project-card-progress-fill');
             if (fill) fill.style.width = percentage + '%';
-            
-            // Update percentage text (keep color #07B6D5, only progress bar changes)
+
             const percent = cardEl.querySelector('.project-card-percentage');
-            if (percent) {
-                percent.textContent = percentage + '%';
-            }
-            
-            // Update time display - show TOTAL time worked
+            if (percent) percent.textContent = percentage + '%';
+
             const durationMin = goal.duration_min || 0;
             const h = Math.floor(totalMinutes / 60);
             const m = totalMinutes % 60;
@@ -174,37 +176,6 @@ async function _updateGoalsProgress(goals) {
         }
     });
 
-    // Initial fetch for all goals using stats manager
-    for (const goal of goals) {
-        const durationMin = goal.duration_min || 0;
-        const color = _getGoalColor(goal);
-        const progress = await statsManager.getTodayProgress(goal.id, durationMin, false);
-        const progressPercent = progress.percentage;
-        const totalMinutes = progress.totalMinutes || 0;
-        
-        // Update card element
-        const cardEl = document.querySelector(`[data-goal-id="${goal.id}"]`);
-        if (cardEl) {
-            // Update progress bar
-            const fill = cardEl.querySelector('.project-card-progress-fill');
-            if (fill) fill.style.width = progressPercent + '%';
-            
-            // Update percentage text (keep color #07B6D5, only progress bar changes)
-            const percent = cardEl.querySelector('.project-card-percentage');
-            if (percent) {
-                percent.textContent = progressPercent + '%';
-            }
-            
-            // Update time display - show TOTAL time worked
-            const h = Math.floor(totalMinutes / 60);
-            const m = totalMinutes % 60;
-            const timeDisplay = durationMin > 0 ? `${h}h ${String(m).padStart(2, "0")}m / ${_fmtMin(durationMin)}` : `${h}h ${String(m).padStart(2, "0")}m`;
-            const timeEl = cardEl.querySelector('.project-card-time');
-            if (timeEl) timeEl.textContent = timeDisplay;
-        }
-    }
-
-    // Start polling for updates
     statsManager.startPolling(goals.map(g => g.id));
 }
 
@@ -258,11 +229,15 @@ async function renderProjectsPageWithGoals() {
     try {
         const goals   = await goalsService.fetchGoals();
         const active  = goals.filter(g => !g.is_complete && g.status !== 'completed');
-        const el      = document.getElementById('projectsContainer');
-        if (el) el.innerHTML = createGoalsList(active);
-        
-        // Load and update progress bars
-        await _updateGoalsProgress(active);
+
+        // Fetch all stats in parallel before rendering so cards show correct progress immediately
+        const statsMap = await _fetchAllGoalStats(active);
+
+        const el = document.getElementById('projectsContainer');
+        if (el) el.innerHTML = createGoalsList(active, statsMap);
+
+        // Register live-update callbacks and start polling
+        _updateGoalsProgress(active);
     } catch (err) {
         const el = document.getElementById('projectsContainer');
         if (el) el.innerHTML = _createErrorState(err.message);


### PR DESCRIPTION
- Pre-fetch all goal stats in parallel before rendering cards/sidebar items so progress bars show correct values on first render instead of animating from 0
- sidebar and project cards both render with correct width, time, and percentage
- Live polling updates still handled via statsManager.subscribe callbacks
- Remove hardcoded background colors from .project-item and .project-item:hover in dark and light mode, replace hover bg with translateY(-1px) transform